### PR TITLE
Remove flags argument from faccessat logger.

### DIFF
--- a/src/intercept_util.c
+++ b/src/intercept_util.c
@@ -954,11 +954,10 @@ intercept_log_syscall(const char *libpath, long nr, long arg0, long arg1,
 				F_OCT_MODE, arg2,
 				result_known, result);
 	} else if (nr == SYS_faccessat) {
-		buf = print_syscall(buf, "faccessat", 4,
+		buf = print_syscall(buf, "faccessat", 3,
 				F_DEC, arg0,
 				F_STR, arg1,
 				F_OCT_MODE, arg2,
-				F_DEC, arg3,
 				result_known, result);
 	} else if (nr == SYS_splice) {
 		buf = print_syscall(buf, "splice", 6,


### PR DESCRIPTION
It doesn't exist in kernel interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/19)
<!-- Reviewable:end -->
