### PR TITLE
Skip log matching when EXPECT_SPURIOUS_SYSCALLS=ON

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,8 +110,8 @@ endforeach()
 
 set(CHECK_LOG_COMMON_ARGS
 	-DMATCH_SCRIPT=${PROJECT_SOURCE_DIR}/utils/match.pl
+	-DEXPECT_SPURIOUS_SYSCALLS=${EXPECT_SPURIOUS_SYSCALLS}
 	-P ${CMAKE_CURRENT_SOURCE_DIR}/check_log.cmake)
-
 
 add_executable(logging_test logging_test.c)
 add_test(NAME "logging"

--- a/test/check_log.cmake
+++ b/test/check_log.cmake
@@ -61,19 +61,21 @@ if(HAD_ERROR)
 	message(FATAL_ERROR "Test failed: ${HAD_ERROR}")
 endif()
 
-execute_process(COMMAND
-	${MATCH_SCRIPT} -o ${LOG_OUTPUT} ${MATCH_FILE}
-	RESULT_VARIABLE MATCH_ERROR)
-
-if(MATCH_ERROR)
-	message(FATAL_ERROR "Log does not match! ${MATCH_ERROR}")
-endif()
-
-if(HAS_SECOND_LOG)
+if(NOT EXPECT_SPURIOUS_SYSCALLS)
 	execute_process(COMMAND
-		${MATCH_SCRIPT} -o ${SECOND_LOG_OUTPUT} ${SECOND_MATCH_FILE}
+		${MATCH_SCRIPT} -o ${LOG_OUTPUT} ${MATCH_FILE}
 		RESULT_VARIABLE MATCH_ERROR)
+
 	if(MATCH_ERROR)
-		message(FATAL_ERROR "Second log does not match! ${MATCH_ERROR}")
+		message(FATAL_ERROR "Log does not match! ${MATCH_ERROR}")
+	endif()
+
+	if(HAS_SECOND_LOG)
+		execute_process(COMMAND
+			${MATCH_SCRIPT} -o ${SECOND_LOG_OUTPUT} ${SECOND_MATCH_FILE}
+			RESULT_VARIABLE MATCH_ERROR)
+		if(MATCH_ERROR)
+			message(FATAL_ERROR "Second log does not match! ${MATCH_ERROR}")
+		endif()
 	endif()
 endif()


### PR DESCRIPTION
It is too hard to predict what is going to end up in the logs
with ASAN, gcov, etc...

The logs are still checked while doing tests without EXPECT_SPURIOUS_SYSCALLS, so this should not be a problem. I gave up on matching logs after this build: https://travis-ci.org/GBuella/syscall_intercept/jobs/249368556

Ref: #7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/32)
<!-- Reviewable:end -->
