### PR TITLE
docker: chmod repo

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -75,6 +75,8 @@ fi
 
 WORKDIR=/${PROJECT}
 
+chmod a+w $HOST_WORKDIR
+
 # Run a container with
 #  - environment variables set (--env)
 #  - host directory containing source mounted (-v)


### PR DESCRIPTION
The build runs with uid 1000 inside docker.
The Precise travis image happens to use this uid for checking
out the sources, but the Trusty travis images uses uid 2000.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/43)
<!-- Reviewable:end -->
