### PR TITLE
Fix decoding of fcntl syscall.

### DIFF
--- a/src/intercept_util.c
+++ b/src/intercept_util.c
@@ -712,7 +712,7 @@ intercept_log_syscall(const char *libpath, long nr, long arg0, long arg1,
 		buf = print_syscall(buf, "fcntl", 3,
 				F_DEC, arg0,
 				F_FCNTL_CMD, arg1,
-				F_DEC, arg1,
+				F_HEX, arg2,
 				result_known, result);
 	} else if (nr == SYS_flock) {
 		buf = print_syscall(buf, "flock", 2,


### PR DESCRIPTION
We were printing 2nd argument twice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/45)
<!-- Reviewable:end -->
