### PR TITLE
CMake: add target generate_syscall_intercept_scoped

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,15 +103,28 @@ add_library(syscall_intercept_unscoped STATIC
 set(syscall_intercept_unscoped_a $<TARGET_FILE:syscall_intercept_unscoped>)
 
 add_custom_command(
-	OUTPUT syscall_intercept_scoped.o
+	OUTPUT syscall_intercept_unscoped.o
 	COMMAND ${CMAKE_LINKER}
 		-r --whole-archive ${syscall_intercept_unscoped_a}
-		-o syscall_intercept_scoped.o
-	COMMAND ${CMAKE_OBJCOPY} --localize-hidden syscall_intercept_scoped.o
-	COMMENT "Hiding symbols")
+		-o syscall_intercept_unscoped.o
+	DEPENDS syscall_intercept_unscoped)
+
+add_custom_command(
+	OUTPUT syscall_intercept_scoped.o
+	COMMAND ${CMAKE_OBJCOPY}
+		--localize-hidden
+		syscall_intercept_unscoped.o
+		syscall_intercept_scoped.o
+	DEPENDS syscall_intercept_unscoped.o)
+
+add_custom_target(generate_syscall_intercept_scoped
+		DEPENDS syscall_intercept_scoped.o)
 
 add_library(syscall_intercept_shared SHARED syscall_intercept_scoped.o)
 add_library(syscall_intercept_static STATIC syscall_intercept_scoped.o)
+
+add_dependencies(syscall_intercept_shared generate_syscall_intercept_scoped)
+add_dependencies(syscall_intercept_static generate_syscall_intercept_scoped)
 
 set_target_properties(syscall_intercept_base_c
 		PROPERTIES C_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
In intermediary target to fix parallel builds. Two
targets depend on syscall_intercept_scoped.o, and apparently
in parallel builds CMake often executed the commands twice, which
sometimes resulted in a failing builds.

An example of such build failure:

```
[ 83%] Built target syscall_intercept_unscoped
[ 83%] Hiding symbols
[ 84%] Hiding symbols
/usr/bin/objcopy: error: the input file 'syscall_intercept_scoped.o' is empty
CMakeFiles/syscall_intercept_static.dir/build.make:61: recipe for target 'syscall_intercept_scoped.o' failed
make[2]: *** [syscall_intercept_scoped.o] Error 1
```

Adding a custom_target hopefully makes things better.
See also:
https://cmake.org/Bug/view.php?id=10082

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/49)
<!-- Reviewable:end -->
