### PR TITLE
Fix a typo in travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
   - ./build.sh
 
 after_success:
-  - if [[ $PUSH_THE_IMAGE -eq 1 ]]; then images/push-image.sh $OS:$OS_VER; fi
+  - if [[ $PUSH_THE_IMAGE -eq 1 ]]; then images/push-image.sh $OS-$OS_VER; fi

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Userspace syscall intercepting library.
  * perl -- for checking coding style
  * pandoc -- for generating the man page
 
-# Travis CI build dependencies #
+### Travis CI build dependencies ###
 
 The travis builds use some scripts to generate a docker images, in which syscall_intercept is built/tested.
 These docker images are pushed to Dockerhub, to be reused in later travis builds.
@@ -33,7 +33,7 @@ The scripts expect four environment variables to be set in the travis environmen
  * DOCKERHUB_PASSWORD - used for logging into Dockerhub
  * GITHUB_REPO - where the repository is available on github (e.g. "pmem/syscall_intercept" )
 
-# How to build #
+### How to build ###
 
 Building libsyscall_intercept requires cmake.
 Example:

--- a/utils/docker/images/Dockerfile.ubuntu-16.04
+++ b/utils/docker/images/Dockerfile.ubuntu-16.04
@@ -65,12 +65,10 @@ RUN apt-get install -y \
 	wget \
 	whois
 
-
 # Add user
 ENV USER user
 ENV USERPASS pass
 RUN useradd -m $USER -g sudo -p `mkpasswd $USERPASS`
-
 
 # Install nvml
 COPY install-nvml.sh install-nvml.sh

--- a/utils/docker/images/build-pmemfile.sh
+++ b/utils/docker/images/build-pmemfile.sh
@@ -70,7 +70,7 @@ cd
 # antool tests.
 git clone https://github.com/pmem/pmemfile.git
 cd pmemfile
-git checkout a7f1d347bfdbabec3b0e0b1dca50542ec6c267e3
+git checkout 6d1e91ecdf86263b9ddf0224963b37715f33874d
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
And a few other superfluous modifications under utils/docker, to trigger
a docker image rebuild.

The travis build on master was meant to trigger docker image pushing once #51 was merged, but actually did not happen (despite the misleading fact that the corresponding travis build is green): 

```
The command "./build.sh" exited with 0.
$ if [[ $PUSH_THE_IMAGE -eq 1 ]]; then images/push-image.sh $OS:$OS_VER; fi
ERROR: wrong argument.
Usage:
    push-image.sh <OS-VER>
where <OS-VER>, for example, can be 'ubuntu-16.04', provided  a Docker image tagged with pmem/syscall_intercept:ubuntu-16.04 exists locally.

Done. Your build exited with 0.
```

Almost there!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/52)
<!-- Reviewable:end -->
