### PR TITLE
Coverity integration fix + optimization

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -96,6 +96,7 @@ sudo docker run --rm --privileged=true --name=$containerName $EXTRA_DOCKER_ARGS 
 	--env COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN \
 	--env COVERITY_SCAN_NOTIFICATION_EMAIL=$COVERITY_SCAN_NOTIFICATION_EMAIL \
 	--env COVERAGE=$COVERAGE \
+	--env PROJECT=$PROJECT \
 	-v $HOST_WORKDIR:$WORKDIR \
 	-w $WORKDIR/utils/docker \
 	$imageName $command

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -47,6 +47,18 @@
 # Docker Hub.
 #
 
+if [[ "$TRAVIS_EVENT_TYPE" == "cron" || "$TRAVIS_BRANCH" == "coverity_scan" ]]; then
+	if [[ $COVERITY -ne 1 ]]; then
+		echo "Skipping non-Coverity job for cron/Coverity build"
+		exit 0
+	fi
+else
+	if [[ $COVERITY -eq 1 ]]; then
+		echo "Skipping Coverity job for non cron/Coverity build"
+		exit 0
+	fi
+fi
+
 if [[ -z "$OS" || -z "$OS_VER" ]]; then
 	echo "ERROR: The variables OS and OS_VER have to be set properly " \
              "(eg. OS=ubuntu, OS_VER=16.04)."


### PR DESCRIPTION
Coverity job has not been configured properly - there was no cron job for syscall_intercept on Travis, so Coverity analysis was never performed (probably with an exception of initial build). When I enabled it, job failed because of empty COVERITY_SCAN_PROJECT_NAME variable (initialized by PROJECT).

This PR fixes that and speeds up Coverity integration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/56)
<!-- Reviewable:end -->
