### PR TITLE
Provide default values of GITHUB_REPO and DOCKERHUB_REPO.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
 
 before_install:
   - export HOST_WORKDIR=`pwd`
+  - export GITHUB_REPO=${GITHUB_REPO:-pmem/syscall_intercept}
+  - export DOCKERHUB_REPO=${DOCKERHUB_REPO:-pmem/syscall_intercept}
   - export PROJECT=syscall_intercept
   - export EXTRA_DOCKER_ARGS=-t
   - cd utils/docker


### PR DESCRIPTION
Without that people who fork syscall_intercept have to set those values
in theirs Travis configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/57)
<!-- Reviewable:end -->
