### PR TITLE
Improve capstone finding code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,9 @@ set(SYSCALL_INTERCEPT_VERSION_PATCH 0)
 set(SYSCALL_INTERCEPT_VERSION
 	${SYSCALL_INTERCEPT_VERSION_MAJOR}.${SYSCALL_INTERCEPT_VERSION_MINOR}.${SYSCALL_INTERCEPT_VERSION_PATCH})
 
+include(cmake/find_capstone.cmake)
 include(GNUInstallDirs)
 include(cmake/toolchain_features.cmake)
-include(cmake/find_capstone.cmake)
 
 # main source files - intentionally excluding src/cmdline_filter.c
 set(SOURCES_C
@@ -75,6 +75,7 @@ set(SOURCES_ASM
 
 
 include_directories(include)
+link_directories(${capstone_LIBRARY_DIRS})
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/cmake/find_capstone.cmake
+++ b/cmake/find_capstone.cmake
@@ -39,5 +39,12 @@ if(NOT capstone_FOUND)
 endif()
 
 if(NOT capstone_FOUND)
-	message(FATAL_ERROR "capstone library not found")
+	message(FATAL_ERROR
+"Unable to find capstone. Please install capstone development files, e.g.:
+sudo apt-get install libcapstone-dev (on Debian, Ubuntu)
+or
+sudo dnf install capstone-devel (on Fedora)
+or see instructions for other ways of installing capstone: http://www.capstone-engine.org/download.html
+If casptone is installed, but cmake didn't manage to find it, there is a slight chance of fixing things by setting some of the following environment variables:
+PKG_CONFIG_PATH, CMAKE_PREFIX_PATH, CMAKE_MODULE_PATH")
 endif()


### PR DESCRIPTION
 * The path to the directory containing capstone's library
provided by capstone's package config file was ignored.
 * Attempting to find capstone is done before checking for toolchain
features, as that is more likely to fail than the other checks, and this
way the user is notified earlier.
 * More verbose error message when capstone is not found.

I cloned capstone from github, installed it (not in a default path), and noticed that syscall_intercept ignored the `-L` flag from capstone's .pc file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/61)
<!-- Reviewable:end -->
