### PR TITLE
Fix label usage in test asm patterns

### DIFF
--- a/test/pattern_loop.in.s
+++ b/test/pattern_loop.in.s
@@ -44,11 +44,11 @@
 .text
 
 text_start:
-0:		xor     rax, rax
+.L0:		xor     rax, rax
 		mov     rax, 1
 		syscall
 		cmp     rax, -1
 		mov     rax, 2
 		syscall
-		loop    0b # this instruction should not be touched
+		loop    .L0 # this instruction should not be touched
 text_end:

--- a/test/pattern_loop.out.s
+++ b/test/pattern_loop.out.s
@@ -41,7 +41,7 @@
 .text
 
 text_start:
-0:		jmp     dst0
+.L0:		jmp     dst0
 		int3
 		int3
 		int3
@@ -58,5 +58,5 @@ text_start:
 		int3
 		int3
 		int3
-		loop    0b
+		loop    .L0
 text_end:

--- a/test/pattern_loop2.in.s
+++ b/test/pattern_loop2.in.s
@@ -47,10 +47,10 @@
 
 text_start:
 		xor     rax, rax # this instruction should be left unchanged
-0:		mov     rax, 1
+.L0:		mov     rax, 1
 		syscall
 		cmp     rax, -1
 		mov     rax, 2
 		syscall
-		loop    0b # this one as well
+		loop    .L0 # this one as well
 text_end:

--- a/test/pattern_loop2.out.s
+++ b/test/pattern_loop2.out.s
@@ -42,7 +42,7 @@
 
 text_start:
 		xor     rax, rax
-0:		jmp     dst0
+.L0:		jmp     dst0
 		int3
 		int3
 		int3
@@ -56,5 +56,5 @@ text_start:
 		int3
 		int3
 		int3
-		loop    0b
+		loop    .L0
 text_end:

--- a/test/pattern_nop_padding1.out.s
+++ b/test/pattern_nop_padding1.out.s
@@ -45,14 +45,14 @@
 
 text_start:
 		xor     rax, rax
-		jmp     1f    # where a nop was originally
-0:		jmp     dst0
+		jmp     .L1    # where a nop was originally
+.L0:		jmp     dst0
 		.byte   0x00
-1:		inc     rax
+.L1:		inc     rax
 		inc     rax
 		inc     rax
 		mov     rax, 1
-		jmp     0b      # where a syscall was originally
+		jmp     .L0      # where a syscall was originally
 		cmp     rax, -1
 		mov     rax, 2
 		jmp     dst1

--- a/test/pattern_nop_padding2.out.s
+++ b/test/pattern_nop_padding2.out.s
@@ -45,16 +45,16 @@
 
 text_start:
 		xor     rax, rax
-		jmp     1f
-0:		jmp     dst0
+		jmp     .L1
+.L0:		jmp     dst0
 		.byte   0x00
 		.byte   0x00
 		.byte   0x00
-1:		inc     rax
+.L1:		inc     rax
 		inc     rax
 		inc     rax
 		mov     rax, 1
-		jmp     0b
+		jmp     .L0
 		cmp     rax, -1
 		mov     rax, 2
 		jmp     dst1

--- a/test/pattern_nop_padding3.out.s
+++ b/test/pattern_nop_padding3.out.s
@@ -45,12 +45,12 @@
 
 text_start:
 		xor     rax, rax
-		jmp     1f
-0:		jmp     dst0
+		jmp     .L1
+.L0:		jmp     dst0
 		.byte   0x00
 		.byte   0x00
 		.byte   0x00
-1:		inc     rax
+.L1:		inc     rax
 		inc     rax
 		dec     rax
 		dec     rax
@@ -88,7 +88,7 @@ text_start:
 		dec     rax
 		inc     rax
 		mov     rax, 1
-		jmp     0b
+		jmp     .L0
 		cmp     rax, -1
 		mov     rax, 2
 		jmp     dst1


### PR DESCRIPTION
The "jmp 0b" "jmp 0f" syntax to jump backward, or forward to
numbered labels doesn't seem to be available in intel syntax
mode when using clang 5, or clang 6.

Fixes #63

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/64)
<!-- Reviewable:end -->
