### PR TITLE
Fix expected form of open in test

### DIFF
--- a/test/libcintercept0.log.match
+++ b/test/libcintercept0.log.match
@@ -7,8 +7,10 @@ $(OPT)$(S) $(XX) -- clone(CLONE_CHILD_CLEARTID | CLONE_CHILD_SETTID | 0x11, (nul
 $(OPT)$(S) $(XX) -- set_robust_list($(XX), $(N)) = ?
 $(OPT)$(S) $(XX) -- set_robust_list($(XX), $(N)) = $(N)
 $(S) $(XX) -- wait4(-1, 0x0, 0x0, 0x0) = $(N)
-$(S) $(XX) -- open($(S), O_RDONLY) = ?
-$(S) $(XX) -- open($(S), O_RDONLY) = $(N)
+$(OPT)$(S) $(XX) -- open($(S), O_RDONLY) = ?
+$(OPT)$(S) $(XX) -- open($(S), O_RDONLY) = $(N)
+$(OPT)$(S) $(XX) -- openat(AT_FDCWD, $(S), O_RDONLY) = ?
+$(OPT)$(S) $(XX) -- openat(AT_FDCWD, $(S), O_RDONLY) = $(N)
 $(S) $(XX) -- fstat($(N), $(XX)) = ?
 $(S) $(XX) -- fstat($(N), $(XX)) = 0
 $(OPT)$(S) $(XX) -- mmap($(XX), $(N), $(N), $(N), $(N), $(XX)) = ?

--- a/test/libcintercept0_child.log.match
+++ b/test/libcintercept0_child.log.match
@@ -1,5 +1,7 @@
-$(S) $(XX) -- open($(S), O_RDONLY) = ?
-$(S) $(XX) -- open($(S), O_RDONLY) = $(N)
+$(OPT)$(S) $(XX) -- open($(S), O_RDONLY) = ?
+$(OPT)$(S) $(XX) -- open($(S), O_RDONLY) = $(N)
+$(OPT)$(S) $(XX) -- openat(AT_FDCWD, $(S), O_RDONLY) = ?
+$(OPT)$(S) $(XX) -- openat(AT_FDCWD, $(S), O_RDONLY) = $(N)
 $(S) $(XX) -- fstat($(N), $(XX)) = ?
 $(S) $(XX) -- fstat($(N), $(XX)) = 0
 $(OPT)$(S) $(XX) -- mmap($(XX), $(N), $(N), $(N), $(N), $(XX)) = ?


### PR DESCRIPTION
Some libc implementations might translate an `open` libc call to an `openat` syscall.

arch-linux glibc-2.26

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/68)
<!-- Reviewable:end -->
