### PR TITLE
Mention pkg-config when capstone is not found

### DIFF
--- a/cmake/find_capstone.cmake
+++ b/cmake/find_capstone.cmake
@@ -40,8 +40,8 @@ endif()
 
 if(NOT capstone_FOUND)
 	message(FATAL_ERROR
-"Unable to find capstone. Please install capstone development files, e.g.:
-sudo apt-get install libcapstone-dev (on Debian, Ubuntu)
+"Unable to find capstone. Please install pkg-config and capstone development files, e.g.:
+sudo apt-get install pkg-config libcapstone-dev (on Debian, Ubuntu)
 or
 sudo dnf install capstone-devel (on Fedora)
 or see instructions for other ways of installing capstone: http://www.capstone-engine.org/download.html


### PR DESCRIPTION
The message about not finding capstone could be confusing,
when pkg-config is not installed, but libcapstone is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/74)
<!-- Reviewable:end -->
