### PR TITLE
Fix error_code display on error

### DIFF
--- a/src/intercept.c
+++ b/src/intercept.c
@@ -517,7 +517,7 @@ xabort_errno(int error_code, const char *msg)
 
 		/* not using libc - inline sprintf */
 		do {
-			*c-- = error_code % 10;
+			*c-- = (error_code % 10) + '0';
 			++len;
 			error_code /= 10;
 		} while (error_code != 0);


### PR DESCRIPTION
errno digits must be converted to ASCII when rendering error code for
display.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/95)
<!-- Reviewable:end -->
