### PR TITLE
Add syscall arguments to clone hooks

### DIFF
--- a/include/libsyscall_intercept_hook_point.h
+++ b/include/libsyscall_intercept_hook_point.h
@@ -56,9 +56,13 @@ extern int (*intercept_hook_point)(long syscall_number,
 			long arg2, long arg3,
 			long arg4, long arg5,
 			long *result);
-
-extern void (*intercept_hook_point_clone_child)(void);
-extern void (*intercept_hook_point_clone_parent)(long pid);
+extern void (*intercept_hook_point_clone_child)(
+			unsigned long flags, void *child_stack,
+			int *ptid, int *ctid, long newtls);
+extern void (*intercept_hook_point_clone_parent)(
+			unsigned long flags, void *child_stack,
+			int *ptid, int *ctid, long newtls,
+			long returned_pid);
 
 /*
  * syscall_no_intercept - syscall without interception

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -67,9 +67,16 @@ int (*intercept_hook_point)(long syscall_number,
 			long *result)
 	__attribute__((visibility("default")));
 
-void (*intercept_hook_point_clone_child)(void)
+void (*intercept_hook_point_clone_child)(
+		unsigned long flags, void *child_stack,
+		int *ptid, int *ctid,
+		long newtls)
 	__attribute__((visibility("default")));
-void (*intercept_hook_point_clone_parent)(long)
+
+void (*intercept_hook_point_clone_parent)(
+		unsigned long flags, void *child_stack,
+		int *ptid, int *ctid,
+		long newtls, long returned_pid)
 	__attribute__((visibility("default")));
 
 bool debug_dumps_on;
@@ -670,12 +677,26 @@ intercept_routine(struct context *context)
 struct wrapper_ret
 intercept_routine_post_clone(struct context *context)
 {
+	struct syscall_desc desc;
+	get_syscall_in_context(context, &desc);
+
 	if (context->rax == 0) {
 		if (intercept_hook_point_clone_child != NULL)
-			intercept_hook_point_clone_child();
+			intercept_hook_point_clone_child(
+				(unsigned long)desc.args[0],
+				(void *)desc.args[1],
+				(int *)desc.args[2],
+				(int *)desc.args[3],
+				desc.args[4]);
 	} else {
 		if (intercept_hook_point_clone_parent != NULL)
-			intercept_hook_point_clone_parent(context->rax);
+			intercept_hook_point_clone_parent(
+				(unsigned long)desc.args[0],
+				(void *)desc.args[1],
+				(int *)desc.args[2],
+				(int *)desc.args[3],
+				desc.args[4],
+				context->rax);
 	}
 
 	return (struct wrapper_ret){.rax = context->rax, .rdx = 1 };

--- a/test/test_clone_thread_preload.c
+++ b/test/test_clone_thread_preload.c
@@ -96,8 +96,18 @@ hook(long syscall_number,
  * of the clone syscall.
  */
 static void
-hook_child(void)
+hook_child(unsigned long clone_flags,
+			void *child_stack,
+			int *ptid,
+			int *ctid,
+			long newtls)
 {
+	(void) clone_flags;
+	(void) child_stack;
+	(void) ptid;
+	(void) ctid;
+	(void) newtls;
+
 	static const char msg[] = "clone_hook_child called\n";
 
 	assert(flags != -1);


### PR DESCRIPTION
This PR adds the missing arguments to the `clone()` system call, so that their values can be inspected when interception hooks are called. In our case, this is useful to keep track of what arguments have been passed to the `clone()` system call and react accordingly.