### PR TITLE
Add intercept hook after kernel syscall completes

### DIFF
--- a/include/libsyscall_intercept_hook_point.h
+++ b/include/libsyscall_intercept_hook_point.h
@@ -59,6 +59,11 @@ extern int (*intercept_hook_point)(long syscall_number,
 
 extern void (*intercept_hook_point_clone_child)(void);
 extern void (*intercept_hook_point_clone_parent)(long pid);
+extern void (*intercept_hook_point_post_kernel)(long syscall_number,
+			long arg0, long arg1,
+			long arg2, long arg3,
+			long arg4, long arg5,
+			long result);
 
 /*
  * syscall_no_intercept - syscall without interception

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -71,6 +71,12 @@ void (*intercept_hook_point_clone_child)(void)
 	__attribute__((visibility("default")));
 void (*intercept_hook_point_clone_parent)(long)
 	__attribute__((visibility("default")));
+void (*intercept_hook_point_post_kernel)(long syscall_number,
+			long arg0, long arg1,
+			long arg2, long arg3,
+			long arg4, long arg5,
+			long result)
+	__attribute__((visibility("default")));
 
 bool debug_dumps_on;
 
@@ -655,6 +661,22 @@ intercept_routine(struct context *context)
 					desc.args[3],
 					desc.args[4],
 					desc.args[5]);
+
+
+		/*
+		 * some users might want to execute code after a syscall has
+		 * been forwarded to the kernel (for example, to check its
+		 * return value).
+		 */
+		if (intercept_hook_point_post_kernel != NULL)
+			intercept_hook_point_post_kernel(desc.nr,
+				desc.args[0],
+				desc.args[1],
+				desc.args[2],
+				desc.args[3],
+				desc.args[4],
+				desc.args[5],
+				result);
 	}
 
 	intercept_log_syscall(patch, &desc, KNOWN, result);


### PR DESCRIPTION
This PR adds an additional `intercept_hook_point_post_kernel` hook to the API that allows users to register a function to be called after a system call has been executed by the kernel by using `syscall_no_intercept`. In our case, this allows us to debug our interception layer, since we can now keep track of/log system call results for those syscalls where we don't really need to do anything. Since this has proved really useful to us, we thought it might be a worthwhile addition to the API.