### PR TITLE
Mark global variable as extern

### DIFF
--- a/src/intercept.h
+++ b/src/intercept.h
@@ -215,7 +215,7 @@ bool is_overwritable_nop(const struct intercept_disasm_result *ins);
 
 void create_jump(unsigned char opcode, unsigned char *from, void *to);
 
-const char *cmdline;
+extern const char *cmdline;
 
 #define PAGE_SIZE ((size_t)0x1000)
 


### PR DESCRIPTION
Fixes compilation with GCC 10. (multiple definition of cmdline)

Note that "Test #43: syscall_format_logging" (`make test`) fails in both cases, without this change compiled by clang as well as with this change compiled by gcc, therefore probably unrelated. I didn't do any further testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/syscall_intercept/107)
<!-- Reviewable:end -->
