### PR TITLE
Fix support for long paths

### DIFF
--- a/src/intercept_desc.c
+++ b/src/intercept_desc.c
@@ -601,7 +601,7 @@ allocate_trampoline_table(struct intercept_desc *desc)
 	}
 
 	FILE *maps;
-	char line[0x100];
+	char line[0x2000];
 	unsigned char *guess; /* Where we would like to allocate the table */
 	size_t size;
 


### PR DESCRIPTION
Increases size of the line buffer in allocate_trampoline_table function,
which is used for /proc/self/maps processing, so it can support longer
file paths.

Theoretically, 64 + 4096 (PATH_MAX) bytes should be enough, but
the buffer size is increased to 8192 bytes, similarly to the buffer
in get_name_from_proc_maps function (intercept.c).

Ref: #109