### PR TITLE
Add clone arguments to callback hooks

### DIFF
--- a/include/libsyscall_intercept_hook_point.h
+++ b/include/libsyscall_intercept_hook_point.h
@@ -58,7 +58,9 @@ extern int (*intercept_hook_point)(long syscall_number,
 			long *result);
 
 extern void (*intercept_hook_point_clone_child)(void);
-extern void (*intercept_hook_point_clone_parent)(long pid);
+extern void (*intercept_hook_point_clone_parent)(
+		long *pid, unsigned long clone_flags, unsigned long newsp,
+		void *parent_tid, void *child_tid, unsigned tid);
 
 /*
  * syscall_no_intercept - syscall without interception

--- a/include/libsyscall_intercept_hook_point.h
+++ b/include/libsyscall_intercept_hook_point.h
@@ -57,7 +57,9 @@ extern int (*intercept_hook_point)(long syscall_number,
 			long arg4, long arg5,
 			long *result);
 
-extern void (*intercept_hook_point_clone_child)(void);
+extern void (*intercept_hook_point_clone_child)(
+		unsigned long clone_flags, unsigned long newsp,
+		void *parent_tid, void *child_tid, unsigned tid);
 extern void (*intercept_hook_point_clone_parent)(
 		long *pid, unsigned long clone_flags, unsigned long newsp,
 		void *parent_tid, void *child_tid, unsigned tid);

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -67,7 +67,9 @@ int (*intercept_hook_point)(long syscall_number,
 			long *result)
 	__attribute__((visibility("default")));
 
-void (*intercept_hook_point_clone_child)(void)
+void (*intercept_hook_point_clone_child)(
+	unsigned long, unsigned long,
+	void *, void *, unsigned)
 	__attribute__((visibility("default")));
 void (*intercept_hook_point_clone_parent)(
 	long *, unsigned long, unsigned long,
@@ -705,7 +707,10 @@ intercept_routine_post_clone(struct context *context)
 {
 	if (context->rax == 0) {
 		if (intercept_hook_point_clone_child != NULL)
-			intercept_hook_point_clone_child();
+			intercept_hook_point_clone_child(
+				context->rdi, context->rsi,
+				(void *)context->rdx, (void *)context->r10,
+				context->r8);
 	} else {
 		if (intercept_hook_point_clone_parent != NULL)
 			intercept_hook_point_clone_parent(

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -705,18 +705,20 @@ intercept_routine(struct context *context)
 struct wrapper_ret
 intercept_routine_post_clone(struct context *context)
 {
+	struct syscall_desc desc;
+	get_syscall_in_context(context, &desc);
 	if (context->rax == 0) {
 		if (intercept_hook_point_clone_child != NULL)
 			intercept_hook_point_clone_child(
-				context->rdi, context->rsi,
-				(void *)context->rdx, (void *)context->r10,
-				context->r8);
+				desc.args[0], desc.args[1],
+				(void *)desc.args[2], (void *)desc.args[3],
+				desc.args[4]);
 	} else {
 		if (intercept_hook_point_clone_parent != NULL)
 			intercept_hook_point_clone_parent(
-				&context->rax, context->rdi, context->rsi,
-				(void *)context->rdx, (void *)context->r10,
-				context->r8);
+				&context->rax, desc.args[0], desc.args[1],
+				(void *)desc.args[2], (void *)desc.args[3],
+				desc.args[4]);
 	}
 
 	return (struct wrapper_ret){.rax = context->rax, .rdx = 1 };

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -69,7 +69,9 @@ int (*intercept_hook_point)(long syscall_number,
 
 void (*intercept_hook_point_clone_child)(void)
 	__attribute__((visibility("default")));
-void (*intercept_hook_point_clone_parent)(long)
+void (*intercept_hook_point_clone_parent)(
+	long *, unsigned long, unsigned long,
+	void *, void *, unsigned)
 	__attribute__((visibility("default")));
 
 bool debug_dumps_on;
@@ -706,7 +708,10 @@ intercept_routine_post_clone(struct context *context)
 			intercept_hook_point_clone_child();
 	} else {
 		if (intercept_hook_point_clone_parent != NULL)
-			intercept_hook_point_clone_parent(context->rax);
+			intercept_hook_point_clone_parent(
+				&context->rax, context->rdi, context->rsi,
+				(void *)context->rdx, (void *)context->r10,
+				context->r8);
 	}
 
 	return (struct wrapper_ret){.rax = context->rax, .rdx = 1 };

--- a/test/test_clone_thread_preload.c
+++ b/test/test_clone_thread_preload.c
@@ -33,7 +33,8 @@
 /*
  * This library's purpose is to hook the syscalls of the program
  * built from test_clone_thread.c, and to check the
- * intercept_hook_point_clone_child hook point while doing so.
+ * intercept_hook_point_clone_child and intercept_hook_point_clone_parent
+ * hook point while doing so.
  *
  * See also: examples/fork_ban.c about forking a new process.
  */
@@ -48,7 +49,15 @@
 #include <syscall.h>
 #include <stdio.h>
 
-static long flags = -1;
+typedef struct {
+	unsigned long clone_flags;
+	unsigned long newsp;
+	void *parent_tid;
+	void *child_tid;
+	unsigned tid;
+} clone_args_t;
+
+static clone_args_t clone_args;
 
 static int
 hook(long syscall_number,
@@ -57,9 +66,6 @@ hook(long syscall_number,
 	long arg4, long arg5,
 	long *result)
 {
-	(void) arg2;
-	(void) arg3;
-	(void) arg4;
 	(void) arg5;
 	(void) result;
 
@@ -80,8 +86,13 @@ hook(long syscall_number,
 	 * therefore the return value (the child's pid) can not be observed,
 	 * or modified.
 	 */
-	if (syscall_number == SYS_clone && (arg1 != 0))
-		flags = arg0;
+	if (syscall_number == SYS_clone && (arg1 != 0)) {
+		clone_args.clone_flags = arg0;
+		clone_args.newsp = arg1;
+		clone_args.parent_tid = (void *) arg2;
+		clone_args.child_tid = (void *) arg3;
+		clone_args.tid = arg4;
+	}
 
 	return 1;
 }
@@ -102,16 +113,32 @@ hook_child(unsigned long clone_flags,
 	void *child_tid,
 	unsigned tid)
 {
-	// suppress unused warnings
-	(void) clone_flags;
-	(void) newsp;
-	(void) parent_tid;
-	(void) child_tid;
-	(void) tid;
 
 	static const char msg[] = "clone_hook_child called\n";
 
-	assert(flags != -1);
+	assert(clone_flags == clone_args.clone_flags);
+	assert(newsp == clone_args.newsp);
+	assert(parent_tid == clone_args.parent_tid);
+	assert(child_tid == clone_args.child_tid);
+	assert(tid == clone_args.tid);
+	syscall_no_intercept(SYS_write, 1, msg, sizeof(msg));
+}
+
+static void
+hook_parent(long *ret,
+	unsigned long clone_flags,
+	unsigned long newsp,
+	void *parent_tid,
+	void *child_tid,
+	unsigned tid) {
+	static const char msg[] = "clone_hook_parent called\n";
+
+	(void) ret;
+	assert(clone_flags == clone_args.clone_flags);
+	assert(newsp == clone_args.newsp);
+	assert(parent_tid == clone_args.parent_tid);
+	assert(child_tid == clone_args.child_tid);
+	assert(tid == clone_args.tid);
 	syscall_no_intercept(SYS_write, 1, msg, sizeof(msg));
 }
 
@@ -120,4 +147,5 @@ init(void)
 {
 	intercept_hook_point = hook;
 	intercept_hook_point_clone_child = hook_child;
+	intercept_hook_point_clone_parent = hook_parent;
 }

--- a/test/test_clone_thread_preload.c
+++ b/test/test_clone_thread_preload.c
@@ -96,8 +96,19 @@ hook(long syscall_number,
  * of the clone syscall.
  */
 static void
-hook_child(void)
+hook_child(unsigned long clone_flags,
+	unsigned long newsp,
+	void *parent_tid,
+	void *child_tid,
+	unsigned tid)
 {
+	// suppress unused warnings
+	(void) clone_flags;
+	(void) newsp;
+	(void) parent_tid;
+	(void) child_tid;
+	(void) tid;
+
 	static const char msg[] = "clone_hook_child called\n";
 
 	assert(flags != -1);


### PR DESCRIPTION
Forwards all arguments from clone to the parent and child hook functions. Additionally, allows the parent hook to set the returned PID if desired. Updates the clone test case to verify arguments are correctly forwarded.

Very similar to PR https://github.com/pmem/syscall_intercept/pull/102 but also updates the test case.