### PR TITLE
Fix clone3 crash in glibc 2.34+

### DIFF
--- a/test/hook_test_clone_preload.c
+++ b/test/hook_test_clone_preload.c
@@ -42,7 +42,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <syscall.h>
-
+#include <linux/sched.h>
 #include "libsyscall_intercept_hook_point.h"
 
 static int hook_counter;
@@ -65,6 +65,10 @@ hook(long syscall_number,
 
 	if (syscall_number == SYS_clone)
 		hook_counter++;
+#ifdef SYS_clone3
+	if (syscall_number == SYS_clone3)
+		hook_counter++;
+#endif
 
 	return 1;
 }

--- a/test/test_clone_thread_preload.c
+++ b/test/test_clone_thread_preload.c
@@ -47,6 +47,7 @@
 #include <assert.h>
 #include <syscall.h>
 #include <stdio.h>
+#include <linux/sched.h>
 
 static long flags = -1;
 
@@ -80,9 +81,15 @@ hook(long syscall_number,
 	 * therefore the return value (the child's pid) can not be observed,
 	 * or modified.
 	 */
-	if (syscall_number == SYS_clone && (arg1 != 0))
+	if (syscall_number == SYS_clone && (arg1 != 0)) {
 		flags = arg0;
-
+	}
+#ifdef SYS_clone3
+	if (syscall_number == SYS_clone3 &&
+			((struct clone_args *)arg0)->stack != 0) {
+		flags = arg0;
+	}
+#endif
 	return 1;
 }
 


### PR DESCRIPTION
glibc has been using clone3 internally since
commit d8ea0d0168b190bdf138a20358293c939509367f.